### PR TITLE
Save lifetime to NanoAOD

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/LHETablesProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/LHETablesProducer.cc
@@ -63,6 +63,7 @@ public:
     std::vector<float> vals_phi;
     std::vector<float> vals_mass;
     std::vector<float> vals_pz;
+    std::vector<float> vals_ctau;
     std::vector<int> vals_pid;
     std::vector<int> vals_status;
     std::vector<int> vals_spin;
@@ -70,11 +71,12 @@ public:
     for (unsigned int i = 0, n = pup.size(); i < n; ++i) {
       int status = hepeup.ISTUP[i];
       int idabs = std::abs(hepeup.IDUP[i]);
-      if (status == 1 || status == -1) {
+      if (status == 1 || status == -1 || hepeup.VTIMUP[i] > 0.) {
         TLorentzVector p4(pup[i][0], pup[i][1], pup[i][2], pup[i][3]);  // x,y,z,t
         vals_pid.push_back(hepeup.IDUP[i]);
         vals_spin.push_back(hepeup.SPINUP[i]);
         vals_status.push_back(status);
+        vals_ctau.push_back(hepeup.VTIMUP[i]);
         if (status == -1) {
           vals_pt.push_back(0);
           vals_eta.push_back(0);
@@ -159,6 +161,7 @@ public:
         "mass", vals_mass, "Mass of LHE particles", nanoaod::FlatTable::FloatColumn, this->precision_);
     outPart->addColumn<float>(
         "incomingpz", vals_pz, "Pz of incoming LHE particles", nanoaod::FlatTable::FloatColumn, this->precision_);
+    outPart->addColumn<float>("ctau", vals_ctau, "ctau of LHE particles", nanoaod::FlatTable::FloatColumn, this->precision_);
     outPart->addColumn<int>("pdgId", vals_pid, "PDG ID of LHE particles", nanoaod::FlatTable::IntColumn);
     outPart->addColumn<int>(
         "status", vals_status, "LHE particle status; -1:incoming, 1:outgoing", nanoaod::FlatTable::IntColumn);


### PR DESCRIPTION
Changes the central NanoAOD LHE table producer such that it saves an LHE particle and its lifetime if the lifetime is > 0.

This could also be implemented as a separate producer in the HNL project with an extension table, but the update here saves a lot of code.